### PR TITLE
pre-finals, final assembly, and finals schedules

### DIFF
--- a/src/schedule/enums.ts
+++ b/src/schedule/enums.ts
@@ -8,12 +8,10 @@ enum Schedule {
   REGULAR,
   BLOCK_ODD,
   BLOCK_EVEN, 
-  SPECIAL_BLOCK_ODD, 
-  SPECIAL_BLOCK_EVEN, 
-  NINE_TWELVE_BLOCK_ODD_FOR_78, 
-  NINE_TWELVE_BLOCK_EVEN_FOR_78, 
-  NINE_TWELVE_SPECIAL_BLOCK_ODD_FOR_78, 
-  NINE_TWELVE_SPECIAL_BLOCK_EVEN_FOR_78, 
+  SBAC_BLOCK_ODD, 
+  SBAC_BLOCK_EVEN, 
+  SBAC_SPECIAL_BLOCK_ODD, 
+  SBAC_SPECIAL_BLOCK_EVEN, 
   EARLY_RELEASE, 
   PRE_FINALS_3264, 
   PRE_FINALS_2156, 
@@ -109,23 +107,17 @@ export function getScheduleName(schedule: Schedule) {
     case Schedule.BLOCK_EVEN: 
       return 'block schedule (2, 4, 6)'; 
       break; 
-    case Schedule.SPECIAL_BLOCK_ODD: 
-      return 'block schedule (3, 1, 5)'; 
+    case Schedule.SBAC_BLOCK_ODD: 
+      return 'SBAC block schedule (1, 3, 5)'; 
       break; 
-    case Schedule.SPECIAL_BLOCK_EVEN: 
-      return 'block schedule (4, 2, 6)'; 
+    case Schedule.SBAC_BLOCK_EVEN: 
+      return 'SBAC block schedule (2, 4, 6)'; 
       break; 
-    case Schedule.NINE_TWELVE_BLOCK_ODD_FOR_78: 
-      return 'high school block schedule (1, 3, 5)'; 
+    case Schedule.SBAC_SPECIAL_BLOCK_ODD: 
+      return 'SBAC block schedule (3, 1, 5)'; 
       break; 
-    case Schedule.NINE_TWELVE_BLOCK_EVEN_FOR_78: 
-      return 'high school block schedule (2, 4, 6)'; 
-      break; 
-    case Schedule.NINE_TWELVE_SPECIAL_BLOCK_ODD_FOR_78: 
-      return 'high school block schedule (3, 1, 5)'; 
-      break; 
-    case Schedule.NINE_TWELVE_SPECIAL_BLOCK_EVEN_FOR_78: 
-      return 'high school block schedule (4, 2, 6)'; 
+    case Schedule.SBAC_SPECIAL_BLOCK_EVEN: 
+      return 'SBAC block schedule (4, 2, 6)'; 
       break; 
     case Schedule.PRE_FINALS_3264: 
       return 'pre-finals schedule (3, 2, 6, 4)'; 

--- a/src/schedule/enums.ts
+++ b/src/schedule/enums.ts
@@ -18,7 +18,7 @@ enum Schedule {
   PRE_FINALS_3264, 
   PRE_FINALS_2156, 
   PRE_FINALS_1345, 
-  ASSEMBLY_SHORT, 
+  FINAL_ASSEMBLY, 
   FINALS_34, 
   FINALS_15, 
   FINALS_26, 
@@ -136,8 +136,8 @@ export function getScheduleName(schedule: Schedule) {
     case Schedule.PRE_FINALS_1345: 
       return 'pre-finals schedule (1, 3, 4, 5)'; 
       break; 
-    case Schedule.ASSEMBLY_SHORT: 
-      return 'short assembly schedule'; 
+    case Schedule.FINAL_ASSEMBLY: 
+      return 'final assembly schedule'; 
       break; 
     case Schedule.FINALS_34: 
       return 'finals schedule (3, 4)'; 

--- a/src/schedule/enums.ts
+++ b/src/schedule/enums.ts
@@ -17,7 +17,7 @@ enum Schedule {
   EARLY_RELEASE, 
   PRE_FINALS_3264, 
   PRE_FINALS_2156, 
-  PRE_FINALS_1235, 
+  PRE_FINALS_1345, 
   ASSEMBLY_SHORT, 
   FINALS_34, 
   FINALS_15, 
@@ -133,8 +133,8 @@ export function getScheduleName(schedule: Schedule) {
     case Schedule.PRE_FINALS_2156: 
       return 'pre-finals schedule (2, 1, 5, 6)'; 
       break; 
-    case Schedule.PRE_FINALS_1235: 
-      return 'pre-finals schedule (1, 2, 3, 5)'; 
+    case Schedule.PRE_FINALS_1345: 
+      return 'pre-finals schedule (1, 3, 4, 5)'; 
       break; 
     case Schedule.ASSEMBLY_SHORT: 
       return 'short assembly schedule'; 

--- a/src/schedule/enums.ts
+++ b/src/schedule/enums.ts
@@ -15,6 +15,13 @@ enum Schedule {
   NINE_TWELVE_SPECIAL_BLOCK_ODD_FOR_78, 
   NINE_TWELVE_SPECIAL_BLOCK_EVEN_FOR_78, 
   EARLY_RELEASE, 
+  PRE_FINALS_3264, 
+  PRE_FINALS_2156, 
+  PRE_FINALS_1235, 
+  ASSEMBLY_SHORT, 
+  FINALS_34, 
+  FINALS_15, 
+  FINALS_26, 
   ASSEMBLY, 
   MINIMUM,
   NONE,
@@ -119,6 +126,27 @@ export function getScheduleName(schedule: Schedule) {
       break; 
     case Schedule.NINE_TWELVE_SPECIAL_BLOCK_EVEN_FOR_78: 
       return 'high school block schedule (4, 2, 6)'; 
+      break; 
+    case Schedule.PRE_FINALS_3264: 
+      return 'pre-finals schedule (3, 2, 6, 4)'; 
+      break; 
+    case Schedule.PRE_FINALS_2156: 
+      return 'pre-finals schedule (2, 1, 5, 6)'; 
+      break; 
+    case Schedule.PRE_FINALS_1235: 
+      return 'pre-finals schedule (1, 2, 3, 5)'; 
+      break; 
+    case Schedule.ASSEMBLY_SHORT: 
+      return 'short assembly schedule'; 
+      break; 
+    case Schedule.FINALS_34: 
+      return 'finals schedule (3, 4)'; 
+      break; 
+    case Schedule.FINALS_15: 
+      return 'finals schedule (1, 5)'; 
+      break; 
+    case Schedule.FINALS_26: 
+      return 'finals schedule (2, 6)'; 
       break; 
     case Schedule.ASSEMBLY: 
       return 'assembly schedule'; 

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -10,7 +10,9 @@ import { NoSchoolSchedule, RegularSchedule, BlockOddSchedule, BlockEvenSchedule,
         PreFinals1345Schedule, FinalAssemblySchedule78, FinalAssemblySchedule12, Finals34Schedule, Finals15Schedule, 
         Finals26Schedule } from './schedules'; 
 
-const allGrades = [7, 8, 9, 10, 11, 12]; 
+export const plus_days = 0; 
+
+export const allGrades = [7, 8, 9, 10, 11, 12]; 
 
 // Native Javascript
 export function getCurrentDate(): any {
@@ -71,16 +73,16 @@ export const grade_special_dates: any = {
 
 export function getScheduleFromDay(month: number, day: number, year: number, week_day: number, grade: number): Schedule {
   let shed = Schedule.NONE; 
-  const high_schooler = 9 <= grade <= 12; 
+  const high_schooler = 9 <= grade && grade <= 12; 
   const date = `${month} - ${day} - ${year}`; 
   const own_grade_dates = grade_special_dates[grade]; 
   const own_section_dates = high_schooler ? hs_special_dates : ms_special_dates; 
   
   if(date in own_grade_dates) {
     shed = own_grade_dates[date]; 
-  else if(date in own_section_dates) {
+  } else if(date in own_section_dates) {
     shed = own_section_dates[date]; 
-  else if(date in school_special_dates) {
+  } else if(date in school_special_dates) {
     shed = school_special_dates[date]; 
   } else {
     switch(week_day) {
@@ -110,7 +112,7 @@ export function toTime(hr: number, min: number) {
 }
 
 export function getFullSchedule(schedule: Schedule, grade: number): any {
-  const high_schooler = 9 <= grade <= 12; 
+  const high_schooler = 9 <= grade && grade <= 12; 
   
   // TODO: Add more schedules
   switch(schedule) {
@@ -194,7 +196,7 @@ export function getFullSchedule(schedule: Schedule, grade: number): any {
         //just a normal assembly schedule
         return AssemblySchedule; 
       } else {
-        return AssemblySchedule78; 
+        return FinalAssemblySchedule78; 
       } 
       break; 
     case Schedule.FINALS_34: 

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -8,7 +8,9 @@ import { NoSchoolSchedule, RegularSchedule, BlockOddSchedule, BlockEvenSchedule,
         NineTwelveBlockEvenScheduleFor78, NineTwelveSpecialBlockOddScheduleFor78, NineTwelveSpecialBlockEvenScheduleFor78, 
         AssemblySchedule7, AssemblySchedule8, EarlyReleaseSchedule78, MinimumSchedule, PreFinals3264Schedule, PreFinals2156Schedule, 
         PreFinals1345Schedule, FinalAssemblySchedule78, FinalAssemblySchedule12, Finals34Schedule, Finals15Schedule, 
-        Finals26Schedule } from './schedules';
+        Finals26Schedule } from './schedules'; 
+
+const allGrades = [7, 8, 9, 10, 11, 12]; 
 
 // Native Javascript
 export function getCurrentDate(): any {

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -27,6 +27,13 @@ export const school_special_dates: any = {
   '4 - 23 - 2019': Schedule.BLOCK_EVEN, 
   '4 - 25 - 2019': Schedule.REGULAR, 
   '5 - 27 - 2019': Schedule.NONE, 
+  '5 - 28 - 2019': Schedule.PRE_FINALS_3264, 
+  '5 - 29 - 2019': Schedule.PRE_FINALS_2156, 
+  '5 - 30 - 2019': Schedule.PRE_FINALS_1345, 
+  '5 - 31 - 2019': Schedule.FINAL_ASSEMBLY, 
+  '6 - 3 - 2019': Schedule.FINALS_34, 
+  '6 - 4 - 2019': Schedule.FINALS_15, 
+  '6 - 5 - 2019': Schedule.FINALS_26, 
   //no finals schedules yet
 }; 
 
@@ -44,6 +51,8 @@ export const grade_special_dates: any = {
   7: {
   }, 
   8: {
+    '6 - 4 - 2019': Schedule.NONE, 
+    '6 - 5 - 2019': Schedule.NONE, 
   }, 
   9: {
   }, 
@@ -52,6 +61,9 @@ export const grade_special_dates: any = {
   11: {
   }, 
   12: {
+    '6 - 3 - 2019': Schedule.NONE, 
+    '6 - 4 - 2019': Schedule.NONE, 
+    '6 - 5 - 2019': Schedule.NONE, 
   }, 
 } 
 

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -4,8 +4,8 @@
 
 import { Day, Schedule, Period } from './enums'; 
 import { NoSchoolSchedule, RegularSchedule, BlockOddSchedule, BlockEvenSchedule, SpecialBlockOddSchedule, SpecialBlockEvenSchedule, 
-        AssemblySchedule, RegularSchedule78, BlockOddSchedule78, BlockEvenSchedule78, NineTwelveBlockOddScheduleFor78, 
-        NineTwelveBlockEvenScheduleFor78, NineTwelveSpecialBlockOddScheduleFor78, NineTwelveSpecialBlockEvenScheduleFor78, 
+        AssemblySchedule, RegularSchedule78, BlockOddSchedule78, BlockEvenSchedule78, HSBlockOddScheduleFor78, 
+        HSBlockEvenScheduleFor78, HSSpecialBlockOddScheduleFor78, HSSpecialBlockEvenScheduleFor78, 
         AssemblySchedule7, AssemblySchedule8, EarlyReleaseSchedule78, MinimumSchedule, PreFinals3264Schedule, PreFinals2156Schedule, 
         PreFinals1345Schedule, FinalAssemblySchedule78, FinalAssemblySchedule12, Finals34Schedule, Finals15Schedule, 
         Finals26Schedule } from './schedules'; 
@@ -128,25 +128,17 @@ export function getFullSchedule(schedule: Schedule, grade: number): any {
     case Schedule.BLOCK_EVEN: 
       return high_schooler ? BlockEvenSchedule : BlockEvenSchedule78; 
       break; 
-    //the following two are exception schedules for 9/12 only, hence why there's no ternary operator
-    case Schedule.SPECIAL_BLOCK_ODD: 
-      return SpecialBlockOddSchedule; 
+    case Schedule.SBAC_BLOCK_ODD: 
+      return high_schooler ? BlockOddSchedule : HSBlockOddScheduleFor78; 
       break; 
-    case Schedule.SPECIAL_BLOCK_EVEN: 
-      return SpecialBlockEvenSchedule; 
+    case Schedule.SBAC_BLOCK_EVEN: 
+      return high_schooler ? BlockEvenSchedule : HSBlockEvenScheduleFor78; 
       break; 
-    //the following four are exception schedules for 7/8 only, hence why there's no ternary operator
-    case Schedule.NINE_TWELVE_BLOCK_ODD_FOR_78: 
-      return NineTwelveBlockOddScheduleFor78; 
+    case Schedule.SBAC_SPECIAL_BLOCK_ODD: 
+      return high_schooler ? SpecialBlockOddSchedule : HSSpecialBlockOddScheduleFor78; 
       break; 
-    case Schedule.NINE_TWELVE_BLOCK_EVEN_FOR_78: 
-      return NineTwelveBlockEvenScheduleFor78; 
-      break; 
-    case Schedule.NINE_TWELVE_SPECIAL_BLOCK_ODD_FOR_78: 
-      return NineTwelveSpecialBlockOddScheduleFor78; 
-      break; 
-    case Schedule.NINE_TWELVE_SPECIAL_BLOCK_EVEN_FOR_78: 
-      return NineTwelveSpecialBlockEvenScheduleFor78; 
+    case Schedule.SBAC_SPECIAL_BLOCK_EVEN: 
+      return high_schooler ? SpecialBlockEvenSchedule : HSSpecialBlockEvenScheduleFor78; 
       break; 
     //pre-finals schedules are the same across all grades, hence there are no switches/ternary operators
     case Schedule.PRE_FINALS_3264: 
@@ -188,7 +180,6 @@ export function getFullSchedule(schedule: Schedule, grade: number): any {
       */ 
       
       break; 
-    //Hypothetically, this would also be used to convey a 9-12 early release day. However, 9-12 doesn't seem to have any. 
     case Schedule.FINAL_ASSEMBLY: 
       if(grade == 12) {
         return FinalAssemblySchedule12; 
@@ -208,6 +199,8 @@ export function getFullSchedule(schedule: Schedule, grade: number): any {
     case Schedule.FINALS_26: 
       return Finals26Schedule; 
       break; 
+    //Hypothetically, this would also be used to convey a 9-12 early release day. However, 9-12 
+    //doesn't seem to have any. 
     case Schedule.EARLY_RELEASE: 
       return EarlyReleaseSchedule78; 
       break; 

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -26,43 +26,43 @@ export const school_special_dates: any = {
   //no finals schedules yet
 }; 
 
-export const seven_eight_special_dates: any = {
-  '4 - 16 - 2019': Schedule.NINE_TWELVE_BLOCK_EVEN_FOR_78, 
-  '4 - 17 - 2019': Schedule.NINE_TWELVE_SPECIAL_BLOCK_ODD_FOR_78, 
-  '4 - 18 - 2019': Schedule.NINE_TWELVE_SPECIAL_BLOCK_EVEN_FOR_78, 
+export const ms_special_dates: any = {
   '4 - 25 - 2019': Schedule.EARLY_RELEASE, 
   '4 - 26 - 2019': Schedule.EARLY_RELEASE, 
   '4 - 29 - 2019': Schedule.EARLY_RELEASE, 
   '4 - 30 - 2019': Schedule.EARLY_RELEASE, 
 } 
 
-export const nine_twelve_special_dates: any = {
-  '4 - 16 - 2019': Schedule.BLOCK_EVEN, 
-  '4 - 17 - 2019': Schedule.SPECIAL_BLOCK_ODD, 
-  '4 - 18 - 2019': Schedule.SPECIAL_BLOCK_EVEN, 
+export const hs_special_dates: any = {
 } 
 
-export function getScheduleFromDay(month: number, day: number, year: number, week_day: number, grade: string): Schedule {
+export const grade_special_dates: any = {
+  7: {
+  }, 
+  8: {
+  }, 
+  9: {
+  }, 
+  10: {
+  }, 
+  11: {
+  }, 
+  12: {
+  }, 
+} 
+
+export function getScheduleFromDay(month: number, day: number, year: number, week_day: number, grade: number): Schedule {
   let shed = Schedule.NONE; 
-  let date = `${month} - ${day} - ${year}`; 
-  let grade_special_dates: any = {}; 
-
-  switch(grade) {
-    case '7': 
-    case '8': 
-      grade_special_dates = seven_eight_special_dates; 
-      break; 
-    case '9-12': 
-      grade_special_dates = nine_twelve_special_dates; 
-      break; 
-    default: 
-      grade_special_dates = {}; 
-      break; 
-  } 
-
-  if(date in grade_special_dates) {
-    shed = grade_special_dates[date]; 
-  } else if(date in school_special_dates) {
+  const high_schooler = 9 <= grade <= 12; 
+  const date = `${month} - ${day} - ${year}`; 
+  const own_grade_dates = grade_special_dates[grade]; 
+  const own_section_dates = high_schooler ? hs_special_dates : ms_special_dates; 
+  
+  if(date in own_grade_dates) {
+    shed = own_grade_dates[date]; 
+  else if(date in own_section_dates) {
+    shed = own_section_dates[date]; 
+  else if(date in school_special_dates) {
     shed = school_special_dates[date]; 
   } else {
     switch(week_day) {

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -91,20 +91,22 @@ export function toTime(hr: number, min: number) {
   return (hr * 60) + min;
 }
 
-export function getFullSchedule(schedule: Schedule, grade: string): any {
+export function getFullSchedule(schedule: Schedule, grade: number): any {
+  const high_schooler = 9 <= grade <= 12; 
+  
   // TODO: Add more schedules
   switch(schedule) {
     case Schedule.NONE: 
       return NoSchoolSchedule; 
       break; 
     case Schedule.REGULAR: 
-      return grade == '9-12' ? RegularSchedule : RegularSchedule78; 
+      return high_schooler ? RegularSchedule : RegularSchedule78; 
       break; 
     case Schedule.BLOCK_ODD: 
-      return grade == '9-12' ? BlockOddSchedule : BlockOddSchedule78; 
+      return high_schooler ? BlockOddSchedule : BlockOddSchedule78; 
       break; 
     case Schedule.BLOCK_EVEN: 
-      return grade == '9-12' ? BlockEvenSchedule : BlockEvenSchedule78; 
+      return high_schooler ? BlockEvenSchedule : BlockEvenSchedule78; 
       break; 
     //the following two are exception schedules for 9/12 only, hence why there's no ternary operator
     case Schedule.SPECIAL_BLOCK_ODD: 
@@ -128,13 +130,16 @@ export function getFullSchedule(schedule: Schedule, grade: string): any {
       break; 
     case Schedule.ASSEMBLY: 
       switch(grade) {
-        case '7': 
+        case 7: 
           return AssemblySchedule7; 
           break; 
-        case '8': 
+        case 8: 
           return AssemblySchedule8; 
           break; 
-        case '9-12': 
+        case 9: 
+        case 10: 
+        case 11: 
+        case 12: 
           return AssemblySchedule; 
           break; 
         default: 
@@ -166,7 +171,7 @@ export function getFullSchedule(schedule: Schedule, grade: string): any {
   } 
 }
 
-export function getPeriod(time: number, schedule: Schedule, grade: string): any {
+export function getPeriod(time: number, schedule: Schedule, grade: number): any {
   const fullSchedule = getFullSchedule(schedule, grade); 
   return fullSchedule.find((p: any) => (p.start <= time && p.end > time)); 
 }
@@ -187,7 +192,7 @@ const periodsFilter = [
   Period.ASSEMBLY,
 ]
 
-export function getUpcomingPeriod(time: number, dateTime: any, schedule: Schedule, grade: string, pAllow = periodsFilter): any {
+export function getUpcomingPeriod(time: number, dateTime: any, schedule: Schedule, grade: number, pAllow = periodsFilter): any {
   const fullSchedule = getFullSchedule(schedule, grade)
   const result = fullSchedule.find((p: any) => (p.start > time && pAllow.indexOf(p.period) !== -1))
   if (result) { return result }
@@ -195,7 +200,7 @@ export function getUpcomingPeriod(time: number, dateTime: any, schedule: Schedul
     // Find the next period across next multiple days
     // TODO: remove the limit
     let daysSince = 1
-    while (daysSince < 100) {
+    while (daysSince < 1000) {
       const nextDate = dateTime.plus({ days: daysSince }).set({ hour: 0, minute: 0 })
       const nextSchedule = getFullSchedule(
         getScheduleFromDay(nextDate.month, nextDate.day, nextDate.year, nextDate.weekday, grade), grade
@@ -208,7 +213,7 @@ export function getUpcomingPeriod(time: number, dateTime: any, schedule: Schedul
     }
 
     // TODO: replace Period.NONE with something else
-    return { start: 0, end: 1440, period: Period.NONE, daysSince: 100 }
+    return { start: 0, end: 1440, period: Period.NONE, daysSince: daysSince }; 
   }
 }
 

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -132,6 +132,16 @@ export function getFullSchedule(schedule: Schedule, grade: number): any {
     case Schedule.NINE_TWELVE_SPECIAL_BLOCK_EVEN_FOR_78: 
       return NineTwelveSpecialBlockEvenScheduleFor78; 
       break; 
+    //pre-finals schedules are the same across all grades, hence there are no switches/ternary operators
+    case Schedule.PRE_FINALS_3264: 
+      return PreFinals3264Schedule; 
+      break; 
+    case Schedule.PRE_FINALS_2156: 
+      return PreFinals2156Schedule; 
+      break; 
+    case Schedule.PRE_FINALS_1345: 
+      return PreFinals1345Schedule; 
+      break; 
     case Schedule.ASSEMBLY: 
       switch(grade) {
         case 7: 
@@ -163,6 +173,25 @@ export function getFullSchedule(schedule: Schedule, grade: number): any {
       
       break; 
     //Hypothetically, this would also be used to convey a 9-12 early release day. However, 9-12 doesn't seem to have any. 
+    case Schedule.FINAL_ASSEMBLY: 
+      if(grade == 12) {
+        return FinalAssemblySchedule12; 
+      } else if(high_schooler) {
+        //just a normal assembly schedule
+        return AssemblySchedule; 
+      } else {
+        return AssemblySchedule78; 
+      } 
+      break; 
+    case Schedule.FINALS_34: 
+      return Finals34Schedule; 
+      break; 
+    case Schedule.FINALS_15: 
+      return Finals15Schedule; 
+      break; 
+    case Schedule.FINALS_26: 
+      return Finals26Schedule; 
+      break; 
     case Schedule.EARLY_RELEASE: 
       return EarlyReleaseSchedule78; 
       break; 

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -4,7 +4,11 @@
 
 import { Day, Schedule, Period } from './enums'; 
 import { NoSchoolSchedule, RegularSchedule, BlockOddSchedule, BlockEvenSchedule, SpecialBlockOddSchedule, SpecialBlockEvenSchedule, 
-        AssemblySchedule, RegularSchedule78, BlockOddSchedule78, BlockEvenSchedule78, NineTwelveBlockOddScheduleFor78, NineTwelveBlockEvenScheduleFor78, NineTwelveSpecialBlockOddScheduleFor78, NineTwelveSpecialBlockEvenScheduleFor78, AssemblySchedule7, AssemblySchedule8, EarlyReleaseSchedule78, MinimumSchedule } from './schedules';
+        AssemblySchedule, RegularSchedule78, BlockOddSchedule78, BlockEvenSchedule78, NineTwelveBlockOddScheduleFor78, 
+        NineTwelveBlockEvenScheduleFor78, NineTwelveSpecialBlockOddScheduleFor78, NineTwelveSpecialBlockEvenScheduleFor78, 
+        AssemblySchedule7, AssemblySchedule8, EarlyReleaseSchedule78, MinimumSchedule, PreFinals3264Schedule, PreFinals2156Schedule, 
+        PreFinals1345Schedule, FinalAssemblySchedule78, FinalAssemblySchedule12, Finals34Schedule, Finals15Schedule, 
+        Finals26Schedule } from './schedules';
 
 // Native Javascript
 export function getCurrentDate(): any {

--- a/src/schedule/schedules.ts
+++ b/src/schedule/schedules.ts
@@ -454,3 +454,5 @@ export const Finals26Schedule: any[] = [
   { start: toTime(11, 0), end: toTime(1, 5), period: Period.PERIOD_6 }, 
   { start: toTime(1, 5), end: toTime(24, 0), period: Period.DONE }, 
 ]; 
+
+

--- a/src/schedule/schedules.ts
+++ b/src/schedule/schedules.ts
@@ -427,3 +427,30 @@ export const MinimumSchedule: any[] = [
   { start: toTime(12, 25), end: toTime(13, 3), period: Period.PERIOD_6 },
   { start: toTime(13, 3), end: toTime(24, 0), period: Period.DONE },
 ]; 
+
+export const Finals34Schedule: any[] = [
+  { start: toTime(0, 0), end: toTime(8, 30), period: Period.NONE }, 
+  { start: toTime(8, 30), end: toTime(10, 35), period: Period.PERIOD_3 }, 
+  { start: toTime(10, 35), end: toTime(10, 55), period: Period.BREAK }, 
+  { start: toTime(10, 55), end: toTime(11, 0), period: Period.BREAK_PASSING }, 
+  { start: toTime(11, 0), end: toTime(1, 5), period: Period.PERIOD_4 }, 
+  { start: toTime(1, 5), end: toTime(24, 0), period: Period.DONE }, 
+]; 
+
+export const Finals15Schedule: any[] = [
+  { start: toTime(0, 0), end: toTime(8, 30), period: Period.NONE }, 
+  { start: toTime(8, 30), end: toTime(10, 35), period: Period.PERIOD_1 }, 
+  { start: toTime(10, 35), end: toTime(10, 55), period: Period.BREAK }, 
+  { start: toTime(10, 55), end: toTime(11, 0), period: Period.BREAK_PASSING }, 
+  { start: toTime(11, 0), end: toTime(1, 5), period: Period.PERIOD_5 }, 
+  { start: toTime(1, 5), end: toTime(24, 0), period: Period.DONE }, 
+]; 
+
+export const Finals26Schedule: any[] = [
+  { start: toTime(0, 0), end: toTime(8, 30), period: Period.NONE }, 
+  { start: toTime(8, 30), end: toTime(10, 35), period: Period.PERIOD_2 }, 
+  { start: toTime(10, 35), end: toTime(10, 55), period: Period.BREAK }, 
+  { start: toTime(10, 55), end: toTime(11, 0), period: Period.BREAK_PASSING }, 
+  { start: toTime(11, 0), end: toTime(1, 5), period: Period.PERIOD_6 }, 
+  { start: toTime(1, 5), end: toTime(24, 0), period: Period.DONE }, 
+]; 

--- a/src/schedule/schedules.ts
+++ b/src/schedule/schedules.ts
@@ -328,8 +328,51 @@ export const EarlyReleaseSchedule78: any[] = [
   { start: toTime(10, 43), end: toTime(11, 39), period: Period.PERIOD_3 },
   { start: toTime(11, 39), end: toTime(11, 45), period: Period.PERIOD_3_PASSING },
   { start: toTime(11, 45), end: toTime(12, 41), period: Period.PERIOD_4 }, 
-  { start: toTime(12, 41), end: toTime(24, 0), period: Period.DONE },
-];
+  { start: toTime(12, 41), end: toTime(24, 0), period: Period.DONE }, 
+]; 
+
+export const PreFinalsSchedule3264: any[] = [
+  { start: toTime(0, 0), end: toTime(8, 30), period: Period.NONE }, 
+  { start: toTime(8, 30), end: toTime(10, 35), period: Period.PERIOD_3 }, 
+  { start: toTime(10, 35), end: toTime(10, 45), period: Period.BREAK }, 
+  { start: toTime(10, 45), end: toTime(10, 50), period: Period.BREAK_PASSING }, 
+  { start: toTime(10, 50), end: toTime(11, 38), period: Period.PERIOD_2 }, 
+  { start: toTime(11, 38), end: toTime(11, 44), period: Period.PERIOD_2_PASSING }, 
+  { start: toTime(11, 44), end: toTime(12, 32), period: Period.PERIOD_6 }, 
+  { start: toTime(12, 32), end: toTime(13, 2), period: Period.LUNCH }, 
+  { start: toTime(13, 2), end: toTime(13, 8), period: Period.LUNCH_PASSING }, 
+  { start: toTime(13, 8), end: toTime(15, 13), period: Period.PERIOD_4 }, 
+  { start: toTime(15, 13), end: toTime(24, 0), period: Period.DONE }, 
+]; 
+
+export const PreFinalsSchedule2156: any[] = [
+  { start: toTime(0, 0), end: toTime(8, 30), period: Period.NONE }, 
+  { start: toTime(8, 30), end: toTime(10, 35), period: Period.PERIOD_2 }, 
+  { start: toTime(10, 35), end: toTime(10, 45), period: Period.BREAK }, 
+  { start: toTime(10, 45), end: toTime(10, 50), period: Period.BREAK_PASSING }, 
+  { start: toTime(10, 50), end: toTime(11, 38), period: Period.PERIOD_1 }, 
+  { start: toTime(11, 38), end: toTime(11, 44), period: Period.PERIOD_1_PASSING }, 
+  { start: toTime(11, 44), end: toTime(12, 32), period: Period.PERIOD_5 }, 
+  { start: toTime(12, 32), end: toTime(13, 2), period: Period.LUNCH }, 
+  { start: toTime(13, 2), end: toTime(13, 8), period: Period.LUNCH_PASSING }, 
+  { start: toTime(13, 8), end: toTime(15, 13), period: Period.PERIOD_6 }, 
+  { start: toTime(15, 13), end: toTime(24, 0), period: Period.DONE }, 
+]; 
+
+export const PreFinalsSchedule1345: any[] = [
+  { start: toTime(0, 0), end: toTime(8, 30), period: Period.NONE }, 
+  { start: toTime(8, 30), end: toTime(10, 35), period: Period.PERIOD_1 }, 
+  { start: toTime(10, 35), end: toTime(10, 45), period: Period.BREAK }, 
+  { start: toTime(10, 45), end: toTime(10, 50), period: Period.BREAK_PASSING }, 
+  { start: toTime(10, 50), end: toTime(11, 38), period: Period.PERIOD_3 }, 
+  { start: toTime(11, 38), end: toTime(11, 44), period: Period.PERIOD_3_PASSING }, 
+  { start: toTime(11, 44), end: toTime(12, 32), period: Period.PERIOD_4 }, 
+  { start: toTime(12, 32), end: toTime(13, 2), period: Period.LUNCH }, 
+  { start: toTime(13, 2), end: toTime(13, 8), period: Period.LUNCH_PASSING }, 
+  { start: toTime(13, 8), end: toTime(15, 13), period: Period.PERIOD_5 }, 
+  { start: toTime(15, 13), end: toTime(24, 0), period: Period.DONE }, 
+]; 
+
 export const MinimumSchedule: any[] = [
   { start: toTime(0, 0), end: toTime(7, 45), period: Period.NONE },
   { start: toTime(7, 45), end: toTime(8, 23), period: Period.PERIOD_0 },

--- a/src/schedule/schedules.ts
+++ b/src/schedule/schedules.ts
@@ -373,6 +373,42 @@ export const PreFinalsSchedule1345: any[] = [
   { start: toTime(15, 13), end: toTime(24, 0), period: Period.DONE }, 
 ]; 
 
+export const FinalAssemblySchedule78: any[] = [
+  { start: toTime(0, 0), end: toTime(7, 28), period: Period.NONE },
+  { start: toTime(7, 28), end: toTime(8, 15), period: Period.PERIOD_0 },
+  { start: toTime(8, 15), end: toTime(8, 30), period: Period.PERIOD_0_PASSING },
+  { start: toTime(8, 30), end: toTime(9, 18), period: Period.PERIOD_1 },
+  { start: toTime(9, 18), end: toTime(9, 24), period: Period.PERIOD_1_PASSING },
+  { start: toTime(9, 24), end: toTime(10, 12), period: Period.PERIOD_2 },
+  { start: toTime(10, 12), end: toTime(11, 0), period: Period.ASSEMBLY },
+  { start: toTime(11, 0), end: toTime(11, 9), period: Period.BREAK },
+  { start: toTime(11, 9), end: toTime(11, 15), period: Period.BREAK_PASSING },
+  { start: toTime(11, 15), end: toTime(12, 3), period: Period.PERIOD_3 }, 
+  { start: toTime(12, 3), end: toTime(12, 9), period: Period.PERIOD_3_PASSING }, 
+  { start: toTime(12, 9), end: toTime(12, 57), period: Period.PERIOD_4 }, 
+  { start: toTime(12, 57), end: toTime(13, 27), period: Period.LUNCH }, 
+  { start: toTime(13, 27), end: toTime(13, 33), period: Period.LUNCH_PASSING }, 
+  { start: toTime(13, 33), end: toTime(14, 21), period: Period.PERIOD_5 },
+  { start: toTime(14, 21), end: toTime(14, 27), period: Period.PERIOD_5_PASSING },
+  { start: toTime(14, 27), end: toTime(15, 15), period: Period.PERIOD_6 },
+  { start: toTime(15, 15), end: toTime(24, 0), period: Period.DONE },
+]; 
+
+export const FinalAssemblySchedule12: any[] = [
+  { start: toTime(0, 0), end: toTime(7, 28), period: Period.NONE },
+  { start: toTime(7, 28), end: toTime(8, 15), period: Period.PERIOD_0 },
+  { start: toTime(8, 15), end: toTime(8, 30), period: Period.PERIOD_0_PASSING },
+  { start: toTime(8, 30), end: toTime(9, 18), period: Period.PERIOD_1 },
+  { start: toTime(9, 18), end: toTime(9, 24), period: Period.PERIOD_1_PASSING },
+  { start: toTime(9, 24), end: toTime(10, 12), period: Period.PERIOD_2 },
+  { start: toTime(10, 12), end: toTime(11, 0), period: Period.ASSEMBLY },
+  { start: toTime(11, 0), end: toTime(11, 9), period: Period.BREAK },
+  { start: toTime(11, 9), end: toTime(11, 15), period: Period.BREAK_PASSING },
+  { start: toTime(11, 15), end: toTime(12, 3), period: Period.PERIOD_3 },
+  { start: toTime(12, 3), end: toTime(12, 33), period: Period.LUNCH }, 
+  { start: toTime(12, 33), end: toTime(24, 0), period: Period.DONE },
+];
+
 export const MinimumSchedule: any[] = [
   { start: toTime(0, 0), end: toTime(7, 45), period: Period.NONE },
   { start: toTime(7, 45), end: toTime(8, 23), period: Period.PERIOD_0 },

--- a/src/schedule/schedules.ts
+++ b/src/schedule/schedules.ts
@@ -172,7 +172,7 @@ export const BlockEvenSchedule78: any[] = [
   { start: toTime(15, 13), end: toTime(24, 0), period: Period.DONE },
 ]; 
 
-export const NineTwelveBlockOddScheduleFor78: any[] = [
+export const HSBlockOddScheduleFor78: any[] = [
   { start: toTime(0, 0), end: toTime(7, 28), period: Period.NONE },
   { start: toTime(7, 28), end: toTime(8, 24), period: Period.PERIOD_0 },
   { start: toTime(8, 24), end: toTime(8, 30), period: Period.PERIOD_0_PASSING },
@@ -188,7 +188,7 @@ export const NineTwelveBlockOddScheduleFor78: any[] = [
   { start: toTime(15, 13), end: toTime(24, 0), period: Period.DONE },
 ];
 
-export const NineTwelveBlockEvenScheduleFor78: any[] = [
+export const HSBlockEvenScheduleFor78: any[] = [
   { start: toTime(0, 0), end: toTime(7, 28), period: Period.NONE },
   { start: toTime(7, 28), end: toTime(8, 24), period: Period.PERIOD_0 },
   { start: toTime(8, 24), end: toTime(8, 30), period: Period.PERIOD_0_PASSING },
@@ -205,7 +205,7 @@ export const NineTwelveBlockEvenScheduleFor78: any[] = [
 ]; 
 
 //special sbac 3, 1, 5 block for 7/8
-export const NineTwelveSpecialBlockOddScheduleFor78: any[] = [
+export const HSSpecialBlockOddScheduleFor78: any[] = [
   { start: toTime(0, 0), end: toTime(7, 28), period: Period.NONE },
   { start: toTime(7, 28), end: toTime(8, 24), period: Period.PERIOD_0 },
   { start: toTime(8, 24), end: toTime(8, 30), period: Period.PERIOD_0_PASSING },
@@ -222,7 +222,7 @@ export const NineTwelveSpecialBlockOddScheduleFor78: any[] = [
 ]; 
 
 //special sbac 4, 2, 6 block for 7/8
-export const NineTwelveSpecialBlockEvenScheduleFor78: any[] = [
+export const HSSpecialBlockEvenScheduleFor78: any[] = [
   { start: toTime(0, 0), end: toTime(7, 28), period: Period.NONE },
   { start: toTime(7, 28), end: toTime(8, 24), period: Period.PERIOD_0 },
   { start: toTime(8, 24), end: toTime(8, 30), period: Period.PERIOD_0_PASSING },

--- a/src/schedule/schedules.ts
+++ b/src/schedule/schedules.ts
@@ -331,7 +331,7 @@ export const EarlyReleaseSchedule78: any[] = [
   { start: toTime(12, 41), end: toTime(24, 0), period: Period.DONE }, 
 ]; 
 
-export const PreFinalsSchedule3264: any[] = [
+export const PreFinals3264Schedule: any[] = [
   { start: toTime(0, 0), end: toTime(8, 30), period: Period.NONE }, 
   { start: toTime(8, 30), end: toTime(10, 35), period: Period.PERIOD_3 }, 
   { start: toTime(10, 35), end: toTime(10, 45), period: Period.BREAK }, 
@@ -345,7 +345,7 @@ export const PreFinalsSchedule3264: any[] = [
   { start: toTime(15, 13), end: toTime(24, 0), period: Period.DONE }, 
 ]; 
 
-export const PreFinalsSchedule2156: any[] = [
+export const PreFinals2156Schedule: any[] = [
   { start: toTime(0, 0), end: toTime(8, 30), period: Period.NONE }, 
   { start: toTime(8, 30), end: toTime(10, 35), period: Period.PERIOD_2 }, 
   { start: toTime(10, 35), end: toTime(10, 45), period: Period.BREAK }, 
@@ -359,7 +359,7 @@ export const PreFinalsSchedule2156: any[] = [
   { start: toTime(15, 13), end: toTime(24, 0), period: Period.DONE }, 
 ]; 
 
-export const PreFinalsSchedule1345: any[] = [
+export const PreFinals1345Schedule: any[] = [
   { start: toTime(0, 0), end: toTime(8, 30), period: Period.NONE }, 
   { start: toTime(8, 30), end: toTime(10, 35), period: Period.PERIOD_1 }, 
   { start: toTime(10, 35), end: toTime(10, 45), period: Period.BREAK }, 
@@ -426,4 +426,4 @@ export const MinimumSchedule: any[] = [
   { start: toTime(12, 18), end: toTime(12, 25), period: Period.PERIOD_5_PASSING },
   { start: toTime(12, 25), end: toTime(13, 3), period: Period.PERIOD_6 },
   { start: toTime(13, 3), end: toTime(24, 0), period: Period.DONE },
-];
+]; 

--- a/src/store.ts
+++ b/src/store.ts
@@ -11,7 +11,7 @@ const defaultConfig = {
     enableThemeAnimations: true,
     showExtraPeriods: false,
     colorTheme: "theme8", 
-    grade: '9-12',
+    grade: 7, 
   },
   changelog: {
     readUpdates: [],

--- a/src/views/BellSchedule.vue
+++ b/src/views/BellSchedule.vue
@@ -67,7 +67,7 @@
 import { Component, Vue } from 'vue-property-decorator'
 import { DateTime, Duration } from 'luxon'
 
-import { printTime, getScheduleFromDay, getPeriod, getFullSchedule } from '@/schedule'
+import { printTime, getScheduleFromDay, getPeriod, getFullSchedule, allGrades } from '@/schedule'
 import { Day, Schedule, Period, getPeriodName, getScheduleName } from '@/schedule/enums'
 import { RegularSchedule, BlockEvenSchedule, BlockOddSchedule } from '@/schedule/schedules' 
 
@@ -77,8 +77,8 @@ const plus_days = 0;
 @Component({})
 export default class Home extends Vue {
   private minutes: number = 0
-  private schedule: Schedule = Schedule.NONE
-  private grade = ''; 
+  private schedule: Schedule = Schedule.NONE; 
+  private grade = allGrades[0]; 
   private currentPeriod = { start: 0, end: 1440, period: Period.NONE }; 
 
   updateStats() {
@@ -190,6 +190,16 @@ export default class Home extends Vue {
   }
 
   mounted() {
+    //correct invalid grade settings if any
+    let grade = this.$store.state.settings.grade; 
+    
+    if(allGrades.indexOf(grade) == -1) {
+      grade = this.allGrades[0]; 
+      
+      this.changeGrade(grade); 
+    } 
+    //note that this didn't make any assignments to this.grade. That's because this part is just to correct invalid settings. 
+    
     setInterval(this.updateStats, 5000)
     this.updateStats()
   }

--- a/src/views/BellSchedule.vue
+++ b/src/views/BellSchedule.vue
@@ -67,12 +67,10 @@
 import { Component, Vue } from 'vue-property-decorator'
 import { DateTime, Duration } from 'luxon'
 
-import { printTime, getScheduleFromDay, getPeriod, getFullSchedule, allGrades } from '@/schedule'
+import { printTime, getScheduleFromDay, getPeriod, getFullSchedule, allGrades, 
+plus_days } from '@/schedule'
 import { Day, Schedule, Period, getPeriodName, getScheduleName } from '@/schedule/enums'
-import { RegularSchedule, BlockEvenSchedule, BlockOddSchedule } from '@/schedule/schedules' 
-
-//testing purposes
-const plus_days = 0; 
+import { RegularSchedule, BlockEvenSchedule, BlockOddSchedule } from '@/schedule/schedules'; 
 
 @Component({})
 export default class Home extends Vue {
@@ -187,14 +185,22 @@ export default class Home extends Vue {
 
   getCertainTime(time: number) {
     return this.$store.state.settings.useMilitaryTime ? this.getCertainTime24(time) : this.getCertainTime12(time)
-  }
+  } 
+
+  updateOptionBL(name: string, value: any): void {
+    this.$store.commit('UPDATE_SETTING', { name, value }); 
+  } 
+
+  changeGrade(grade: number) {
+    this.updateOptionBL('grade', grade); 
+  } 
 
   mounted() {
     //correct invalid grade settings if any
     let grade = this.$store.state.settings.grade; 
     
     if(allGrades.indexOf(grade) == -1) {
-      grade = this.allGrades[0]; 
+      grade = allGrades[0]; 
       
       this.changeGrade(grade); 
     } 

--- a/src/views/Now.vue
+++ b/src/views/Now.vue
@@ -206,7 +206,15 @@ export default class Now extends Vue {
     else {
       return this.getCurrentTimeParts24()
     }
-  }
+  } 
+  
+  created() {
+    let grade = this.$store.state.settings.grade; 
+    
+    if(!(grade in this.allGrades)) {
+      grade = this.allGrades[0]; 
+    
+    this.grade = grade; 
 
   mounted() {
     setInterval(this.updateStats, 5000)

--- a/src/views/Now.vue
+++ b/src/views/Now.vue
@@ -225,6 +225,7 @@ export default class Now extends Vue {
       
       this.changeGrade(grade); 
     } 
+    //note that this didn't make any assignments to this.grade. That's because the assignments are made in this.updateStats. 
     
     setInterval(this.updateStats, 5000)
     this.updateStats()

--- a/src/views/Now.vue
+++ b/src/views/Now.vue
@@ -43,13 +43,11 @@
 import { Component, Vue } from 'vue-property-decorator';
 import { DateTime, Duration } from 'luxon';
 
-import { printTime, getScheduleFromDay, getPeriod, getUpcomingPeriod, allGrades } from '@/schedule';
+import { printTime, getScheduleFromDay, getPeriod, getUpcomingPeriod, allGrades, 
+plus_days } from '@/schedule';
 import { Day, Schedule, Period, getPeriodName, getScheduleName } from '@/schedule/enums';
 import { RegularSchedule, BlockEvenSchedule, BlockOddSchedule } from '@/schedule/schedules';
-import { Changelog } from '../changelog' 
-
-//testing purposes
-const plus_days = 0; 
+import { Changelog } from '../changelog'; 
 
 @Component({})
 export default class Now extends Vue {
@@ -208,11 +206,11 @@ export default class Now extends Vue {
     }
   } 
   
-  updateOptionBL(name: string, value: boolean): void {
+  updateOptionBL(name: string, value: any): void {
     this.$store.commit('UPDATE_SETTING', { name, value }); 
   } 
-  
-  changeGrade(grade) {
+
+  changeGrade(grade: number) {
     this.updateOptionBL('grade', grade); 
   } 
 
@@ -221,7 +219,7 @@ export default class Now extends Vue {
     let grade = this.$store.state.settings.grade; 
     
     if(allGrades.indexOf(grade) == -1) {
-      grade = this.allGrades[0]; 
+      grade = allGrades[0]; 
       
       this.changeGrade(grade); 
     } 

--- a/src/views/Now.vue
+++ b/src/views/Now.vue
@@ -43,7 +43,7 @@
 import { Component, Vue } from 'vue-property-decorator';
 import { DateTime, Duration } from 'luxon';
 
-import { printTime, getScheduleFromDay, getPeriod, getUpcomingPeriod } from '@/schedule';
+import { printTime, getScheduleFromDay, getPeriod, getUpcomingPeriod, allGrades } from '@/schedule';
 import { Day, Schedule, Period, getPeriodName, getScheduleName } from '@/schedule/enums';
 import { RegularSchedule, BlockEvenSchedule, BlockOddSchedule } from '@/schedule/schedules';
 import { Changelog } from '../changelog' 
@@ -55,8 +55,8 @@ const plus_days = 0;
 export default class Now extends Vue {
   private minutes: number = 0
   private currentDateTime: any
-  private schedule: Schedule = Schedule.NONE
-  private grade = ''; 
+  private schedule: Schedule = Schedule.NONE; 
+  private grade = allGrades[0]; 
   private currentPeriod = { start: 0, end: 1440, period: Period.NONE }; 
   private allLogs: any[] = []
   public useNextPeriodStartAsEnd = false    // TODO: Find a better variable name
@@ -208,15 +208,24 @@ export default class Now extends Vue {
     }
   } 
   
-  created() {
-    let grade = this.$store.state.settings.grade; 
-    
-    if(!(grade in this.allGrades)) {
-      grade = this.allGrades[0]; 
-    
-    this.grade = grade; 
+  updateOptionBL(name: string, value: boolean): void {
+    this.$store.commit('UPDATE_SETTING', { name, value }); 
+  } 
+  
+  changeGrade(grade) {
+    this.updateOptionBL('grade', grade); 
+  } 
 
   mounted() {
+    //correct invalid grade settings if any
+    let grade = this.$store.state.settings.grade; 
+    
+    if(allGrades.indexOf(grade) == -1) {
+      grade = this.allGrades[0]; 
+      
+      this.changeGrade(grade); 
+    } 
+    
     setInterval(this.updateStats, 5000)
     this.updateStats()
 

--- a/src/views/Now.vue
+++ b/src/views/Now.vue
@@ -225,7 +225,7 @@ export default class Now extends Vue {
       
       this.changeGrade(grade); 
     } 
-    //note that this didn't make any assignments to this.grade. That's because the assignments are made in this.updateStats. 
+    //note that this didn't make any assignments to this.grade. That's because this part is just to correct invalid settings. 
     
     setInterval(this.updateStats, 5000)
     this.updateStats()

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -128,6 +128,7 @@ export default class Home extends Vue {
       this.grade = allGrades[0]; 
       
       this.updateGrade(); 
+    } 
     
     this.allThemes = Themes
   }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -98,15 +98,15 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import { Themes } from '../themes';
+import { Themes } from '../themes'; 
+import { allGrades } from '@/schedules'; 
 
 @Component({})
 export default class Home extends Vue {
   public appVersion = `v${process.env.VUE_APP_VERSION} (b${process.env.VUE_APP_COMMIT_COUNT.trim()}#${process.env.VUE_APP_COMMIT_SHASH.trim()})`
   colorThemeId = this.$store.state.settings.colorTheme
-  grade = this.$store.state.settings.grade
-  allThemes: any[] = [] 
-  allGrades = [7, 8, 9, 10, 11, 12]; 
+  grade = allGrades[0]; 
+  allThemes: any[] = []; 
 
   updateOptionBL(name: string, value: boolean): void {
     this.$store.commit('UPDATE_SETTING', { name, value })
@@ -121,6 +121,14 @@ export default class Home extends Vue {
   } 
 
   mounted() {
+    //this part is to prevent invalid grade values
+    let grade = this.$store.state.settings.grade; 
+    
+    if(!(grade in allGrades)) {
+      grade = allGrades[0]; 
+    } 
+    
+    this.grade = grade; 
     this.allThemes = Themes
   }
 }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -106,7 +106,7 @@ export default class Home extends Vue {
   colorThemeId = this.$store.state.settings.colorTheme
   grade = this.$store.state.settings.grade
   allThemes: any[] = [] 
-  allGrades: any[] = ['7', '8', '9-12'] 
+  allGrades = [7, 8, 9, 10, 11, 12]; 
 
   updateOptionBL(name: string, value: boolean): void {
     this.$store.commit('UPDATE_SETTING', { name, value })

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -122,13 +122,13 @@ export default class Home extends Vue {
 
   mounted() {
     //this part is to prevent invalid grade values
-    let grade = this.$store.state.settings.grade; 
+    this.grade = this.$store.state.settings.grade; 
     
-    if(!(grade in allGrades)) {
-      grade = allGrades[0]; 
-    } 
+    if(allGrades.indexOf(this.grade) == -1) {
+      this.grade = allGrades[0]; 
+      
+      this.updateGrade(); 
     
-    this.grade = grade; 
     this.allThemes = Themes
   }
 }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -99,16 +99,17 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { Themes } from '../themes'; 
-import { allGrades } from '@/schedules'; 
+import { allGrades } from '@/schedule'; 
 
 @Component({})
 export default class Home extends Vue {
   public appVersion = `v${process.env.VUE_APP_VERSION} (b${process.env.VUE_APP_COMMIT_COUNT.trim()}#${process.env.VUE_APP_COMMIT_SHASH.trim()})`
   colorThemeId = this.$store.state.settings.colorTheme
   grade = allGrades[0]; 
+  allGrades = allGrades; 
   allThemes: any[] = []; 
 
-  updateOptionBL(name: string, value: boolean): void {
+  updateOptionBL(name: string, value: any): void {
     this.$store.commit('UPDATE_SETTING', { name, value })
   }
 


### PR DESCRIPTION
This implements the schedules for the pre-finals, final assembly, and finals days. It also comes with a rework to the grade setting, now having a separate option for each grade. Also the grade setting is now stored as a number. **Final**ly, I made some refactors to the "special dates" system and moved the `plus_days` variable out of `views/BellSchedule.vue` and `views/Now.vue`, and into `schedule/index.ts`. 