### PR TITLE
Take out block schedules

### DIFF
--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -119,10 +119,10 @@ export function getScheduleFromDay(month: number, day: number, year: number, wee
             shed = Schedule.REGULAR;
             break;
           case Day.WEDNESDAY:
-            shed = Schedule.BLOCK_ODD;
+            shed = Schedule.REGULAR;//BLOCK_ODD;
             break;
           case Day.THURSDAY:
-            shed = Schedule.BLOCK_EVEN;
+            shed = Schedule.REGULAR;//BLOCK_EVEN;
             break; 
         } 
       } 


### PR DESCRIPTION
We need to have either this PR pulled or Brian's PR pulled by first period so I'm going to put out this PR now. If Brian's PR isn't up by the beginning of 0 period, I'm going to try to pull this during 0 period with Ryan to sanity check me. This is just a temporary fix though.

I'm taking out the block schedules. They are easily replaceable and should be replaced after this week but tomorrow is not a block schedule and this must be fixed and TBH, I don't have the time or energy to make only specific days exceptions;