### PR TITLE
[fix] Animation switch control radial gradient

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -105,17 +105,18 @@ html, body, #app-container {
   background-size: 400% 400%;
   animation: AnimatedTheme 20s ease infinite;
 
-  &.toggleOff {
-    background-size: 100% 100%;
-    animation: none;
-  }
-
   &.toggleRadial {
     background: radial-gradient(var(--gradient-colors, "#42b983, #2f9768"));
     background-size: 200%, 200%;
     background-position: center;
     animation: AnimatedRadial 10s ease infinite;  
   }
+
+  &.toggleOff {
+    background-size: 100% 100%;
+    animation: none;
+  }
+
 }
 #app {
   font-family: 'Niramit', Avenir, sans-serif;


### PR DESCRIPTION
before radial-gradient animations were enabled by default and could not be controlled by enabling animations switch.  Now it is possible to disable radial-gradient animations with the switch.