### PR TITLE
Remove Cohort Names in May

### DIFF
--- a/src/schedule/enums.ts
+++ b/src/schedule/enums.ts
@@ -89,6 +89,7 @@ enum Period {
   G_G_LUNCH,
   PERIOD_OFFICE_HOURS_A,
   PERIOD_OFFICE_HOURS_B,
+  PERIOD_OFFICE_HOURS_I,
   // Normal Schedules
   PERIOD_0,
   PERIOD_0_PASSING,
@@ -173,6 +174,7 @@ export function getPeriodName(period: Period) {
   else if (period === Period.G_G_LUNCH) { return 'Grab & Go Lunch'; }
   else if (period === Period.PERIOD_OFFICE_HOURS_A) { return 'Office Hours / Period 0 Cohort A'; }
   else if (period === Period.PERIOD_OFFICE_HOURS_B) { return 'Office Hours / Period 0 Cohort B'; }
+  else if (period === Period.PERIOD_OFFICE_HOURS_I) { return 'Office Hours / Period 0 In Person'; }
   // Normal Schedules
   else if (period === Period.PERIOD_0) { return 'Period 0'; }
   else if (period === Period.PERIOD_0_PASSING) { return 'Passing After Period 0'; }

--- a/src/schedule/enums.ts
+++ b/src/schedule/enums.ts
@@ -11,6 +11,8 @@ enum Schedule {
   COHORT_A_EVEN,
   COHORT_B_ODD,
   COHORT_B_EVEN,
+  IN_PERSON_ODD,
+  IN_PERSON_EVEN,
   // Normal Schedules
   REGULAR,
   BLOCK_ODD,
@@ -58,7 +60,7 @@ enum Day {
 // Passing break is defined here as the
 // short break after a certain period/block
 enum Period {
-  // Hybrid and Virtual - O is online, A is Cohort A, B is Cohort B
+  // Hybrid and Virtual - O is online, A is Cohort A, B is Cohort B, I is In Person (both cohorts combined)
   PERIOD_0_O,
   PERIOD_1_O,
   PERIOD_2_O,
@@ -78,6 +80,12 @@ enum Period {
   PERIOD_4_B,
   PERIOD_5_B,
   PERIOD_6_B,
+  PERIOD_1_I,
+  PERIOD_2_I,
+  PERIOD_3_I,
+  PERIOD_4_I,
+  PERIOD_5_I,
+  PERIOD_6_I,
   G_G_LUNCH,
   PERIOD_OFFICE_HOURS_A,
   PERIOD_OFFICE_HOURS_B,
@@ -156,6 +164,12 @@ export function getPeriodName(period: Period) {
   else if (period === Period.PERIOD_4_B) { return 'Period 4 Cohort B In Person'; }
   else if (period === Period.PERIOD_5_B) { return 'Period 5 Cohort B In Person'; }
   else if (period === Period.PERIOD_6_B) { return 'Period 6 Cohort B In Person'; }
+  else if (period === Period.PERIOD_1_I) { return 'Period 1 In Person'; }
+  else if (period === Period.PERIOD_2_I) { return 'Period 2 In Person'; }
+  else if (period === Period.PERIOD_3_I) { return 'Period 3 In Person'; }
+  else if (period === Period.PERIOD_4_I) { return 'Period 4 In Person'; }
+  else if (period === Period.PERIOD_5_I) { return 'Period 5 In Person'; }
+  else if (period === Period.PERIOD_6_I) { return 'Period 6 In Person'; }
   else if (period === Period.G_G_LUNCH) { return 'Grab & Go Lunch'; }
   else if (period === Period.PERIOD_OFFICE_HOURS_A) { return 'Office Hours / Period 0 Cohort A'; }
   else if (period === Period.PERIOD_OFFICE_HOURS_B) { return 'Office Hours / Period 0 Cohort B'; }
@@ -222,16 +236,22 @@ export function getScheduleName(schedule: Schedule) {
       return 'Normal Virtual Day';
       break;
     case Schedule.COHORT_A_ODD:
-      return 'Block Odd (Cohort A in person)';
+      return 'Block ODD (Cohort A in person)';
       break;
     case Schedule.COHORT_A_EVEN:
       return 'Block EVEN (Cohort A in person)';
       break;
     case Schedule.COHORT_B_ODD:
-      return 'Block Odd (Cohort B in person)';
+      return 'Block ODD (Cohort B in person)';
       break;
     case Schedule.COHORT_B_EVEN:
       return 'Block EVEN (Cohort B in person)';
+      break;
+    case Schedule.IN_PERSON_ODD:
+      return 'Block ODD (In Person)';
+      break;
+    case Schedule.IN_PERSON_EVEN:
+      return 'Block EVEN (In Person)';
       break;
       // Normal Schedules
     case Schedule.REGULAR:

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -4,7 +4,7 @@
 
 import { MDYDate } from './mdy_date';
 import { Day, Schedule, Period } from './enums';
-import { HybridVirtualDay, CohortABlockOdd, CohortABlockEven, CohortBBlockOdd, CohortBBlockEven, /* <--- hybrid and virtual days*/ NoSchoolSchedule, NoEventSchedule, WeirdAssemblySchedule, WeirdAssemblySchedule78, RegularSchedule,  BlockOddSchedule, BlockEvenSchedule,
+import { HybridVirtualDay, CohortABlockOdd, CohortABlockEven, CohortBBlockOdd, CohortBBlockEven, InPersonBlockOdd, InPersonBlockEven, /* <--- hybrid and virtual days*/ NoSchoolSchedule, NoEventSchedule, WeirdAssemblySchedule, WeirdAssemblySchedule78, RegularSchedule,  BlockOddSchedule, BlockEvenSchedule,
         SmallGroups12, SmallGroups34, SmallGroups56, SmallGroupsWellnessClubs, SmallGroups0Clubs,
         ReverseBlockOddSchedule, MinimumReverseBlockOddSchedule78, SpecialBlockOddSchedule, SpecialBlockEvenSchedule, AssemblySchedule, RegularSchedule78,
         BlockOddSchedule78, BlockEvenSchedule78, HSBlockOddScheduleFor78, HSBlockEvenScheduleFor78, HSSpecialBlockOddScheduleFor78,
@@ -37,7 +37,8 @@ const breaks: any[] = [tgBreak, winterBreak, springBreak, summerBreak];
 
 const summerSchool: [MDYDate, MDYDate] = [new MDYDate(6, 3, 2021), new MDYDate(8, 16, 2021)];
 const blockSwitch: [MDYDate, MDYDate] = [new MDYDate(11, 11, 2019), new MDYDate(2, 17, 2020)];
-const hybrid: [MDYDate, MDYDate] = [new MDYDate(4, 12, 2021), new MDYDate(6, 2, 2021)];
+const hybrid: [MDYDate, MDYDate] = [new MDYDate(4, 12, 2021), new MDYDate(5, 1, 2021)];
+const combined: [MDYDate, MDYDate] = [new MDYDate(5, 3, 2021), new MDYDate(6, 2, 2021)]
 
 export const schoolSpecialDates: any = {
   '8 - 19 - 2020': Schedule.REGULAR,
@@ -133,6 +134,7 @@ export function getScheduleFromDay(month: number, day: number, year: number, wee
     const isSummerSchool = dateObj.between(...summerSchool);
     const isBlockSwitched = dateObj.between(...blockSwitch);
     const isHybrid = dateObj.between(...hybrid);
+    const isCombined = dateObj.between(...combined)
 
     if (isSummerSchool) {
       switch (weekDay) {
@@ -215,6 +217,24 @@ export function getScheduleFromDay(month: number, day: number, year: number, wee
               shed = Schedule.COHORT_B_EVEN;
               break;
           }
+        } else if (isCombined && highSchooler === 3 || isCombined && highSchooler === 2) {
+          switch (weekDay) {
+            case Day.SUNDAY:
+            case Day.SATURDAY:
+              shed = Schedule.NONE;
+              break;
+            case Day.MONDAY:
+              shed = Schedule.ONLINE;
+              break;
+            case Day.TUESDAY:
+            case Day.THURSDAY:
+              shed = Schedule.IN_PERSON_ODD;
+              break;
+            case Day.WEDNESDAY:
+            case Day.FRIDAY:
+              shed = Schedule.IN_PERSON_EVEN;
+              break;
+          }
         } else {
           switch (weekDay) {
             case Day.SUNDAY:
@@ -286,6 +306,10 @@ export function getFullSchedule(schedule: Schedule, grade: number): any {
       return CohortBBlockOdd;
     case Schedule.COHORT_B_EVEN:
       return CohortBBlockEven;
+    case Schedule.IN_PERSON_ODD:
+      return InPersonBlockOdd;
+    case Schedule.IN_PERSON_EVEN:
+      return InPersonBlockEven;
 
     // stop hybrid and virtual
     case Schedule.REGULAR:
@@ -573,9 +597,16 @@ export const periodsFilter = [
   Period.PERIOD_4_B,
   Period.PERIOD_5_B,
   Period.PERIOD_6_B,
+  Period.PERIOD_1_I,
+  Period.PERIOD_2_I,
+  Period.PERIOD_3_I,
+  Period.PERIOD_4_I,
+  Period.PERIOD_5_I,
+  Period.PERIOD_6_I,
   Period.G_G_LUNCH,
   Period.PERIOD_OFFICE_HOURS_A,
   Period.PERIOD_OFFICE_HOURS_B,
+  Period.PERIOD_OFFICE_HOURS_I,
 ];
 
 export const excludeZero = [
@@ -620,9 +651,16 @@ export const excludeZero = [
   Period.PERIOD_4_B,
   Period.PERIOD_5_B,
   Period.PERIOD_6_B,
+  Period.PERIOD_1_I,
+  Period.PERIOD_2_I,
+  Period.PERIOD_3_I,
+  Period.PERIOD_4_I,
+  Period.PERIOD_5_I,
+  Period.PERIOD_6_I,
   Period.G_G_LUNCH,
   Period.PERIOD_OFFICE_HOURS_A,
   Period.PERIOD_OFFICE_HOURS_B,
+  Period.PERIOD_OFFICE_HOURS_I,
 ];
 
 export const excludeSix = [
@@ -664,9 +702,15 @@ export const excludeSix = [
   Period.PERIOD_3_B,
   Period.PERIOD_4_B,
   Period.PERIOD_5_B,
+  Period.PERIOD_1_I,
+  Period.PERIOD_2_I,
+  Period.PERIOD_3_I,
+  Period.PERIOD_4_I,
+  Period.PERIOD_5_I,
   Period.G_G_LUNCH,
   Period.PERIOD_OFFICE_HOURS_A,
   Period.PERIOD_OFFICE_HOURS_B,
+  Period.PERIOD_OFFICE_HOURS_I,
 ];
 
 export const excludeZeroAndSix = [
@@ -708,9 +752,15 @@ export const excludeZeroAndSix = [
   Period.PERIOD_3_B,
   Period.PERIOD_4_B,
   Period.PERIOD_5_B,
+  Period.PERIOD_1_I,
+  Period.PERIOD_2_I,
+  Period.PERIOD_3_I,
+  Period.PERIOD_4_I,
+  Period.PERIOD_5_I,
   Period.G_G_LUNCH,
   Period.PERIOD_OFFICE_HOURS_A,
   Period.PERIOD_OFFICE_HOURS_B,
+  Period.PERIOD_OFFICE_HOURS_I,
 ];
 
 export const allFilter = [
@@ -772,9 +822,16 @@ export const allFilter = [
   Period.PERIOD_4_B,
   Period.PERIOD_5_B,
   Period.PERIOD_6_B,
+  Period.PERIOD_1_I,
+  Period.PERIOD_2_I,
+  Period.PERIOD_3_I,
+  Period.PERIOD_4_I,
+  Period.PERIOD_5_I,
+  Period.PERIOD_6_I,
   Period.G_G_LUNCH,
   Period.PERIOD_OFFICE_HOURS_A,
   Period.PERIOD_OFFICE_HOURS_B,
+  Period.PERIOD_OFFICE_HOURS_I,
   Period.PREP,
   Period.DONE,
 ];

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -38,7 +38,7 @@ const breaks: any[] = [tgBreak, winterBreak, springBreak, summerBreak];
 const summerSchool: [MDYDate, MDYDate] = [new MDYDate(6, 3, 2021), new MDYDate(8, 16, 2021)];
 const blockSwitch: [MDYDate, MDYDate] = [new MDYDate(11, 11, 2019), new MDYDate(2, 17, 2020)];
 const hybrid: [MDYDate, MDYDate] = [new MDYDate(4, 12, 2021), new MDYDate(5, 1, 2021)];
-const combined: [MDYDate, MDYDate] = [new MDYDate(5, 3, 2021), new MDYDate(6, 2, 2021)]
+const combined: [MDYDate, MDYDate] = [new MDYDate(5, 3, 2021), new MDYDate(6, 2, 2021)];
 
 export const schoolSpecialDates: any = {
   '8 - 19 - 2020': Schedule.REGULAR,
@@ -134,7 +134,7 @@ export function getScheduleFromDay(month: number, day: number, year: number, wee
     const isSummerSchool = dateObj.between(...summerSchool);
     const isBlockSwitched = dateObj.between(...blockSwitch);
     const isHybrid = dateObj.between(...hybrid);
-    const isCombined = dateObj.between(...combined)
+    const isCombined = dateObj.between(...combined);
 
     if (isSummerSchool) {
       switch (weekDay) {

--- a/src/schedule/schedules.ts
+++ b/src/schedule/schedules.ts
@@ -181,6 +181,40 @@ export const CohortBBlockEven: any[] = [ // Has no small groups
   { start: toTime(14, 40), end: toTime(15, 20), period: Period.PREP },
   { start: toTime(15, 20), end: toTime(24, 0), period: Period.DONE },
 ];
+export const InPersonBlockOdd: any[] = [ // Has no small groups
+  { start: toTime(0, 0), end: toTime(7, 40), period: Period.NONE },
+  { start: toTime(7, 40), end: toTime(8, 20), period: Period.PERIOD_0_O },
+  { start: toTime(8, 20), end: toTime(8, 30), period: Period.PERIOD_0_PASSING },
+  { start: toTime(8, 30), end: toTime(9, 55), period: Period.PERIOD_1_I },
+  { start: toTime(9, 55), end: toTime(10, 2), period: Period.PERIOD_1_PASSING },
+  { start: toTime(10, 2), end: toTime(11, 22), period: Period.PERIOD_3_I },
+  { start: toTime(11, 22), end: toTime(11, 33), period: Period.BREAK },
+  { start: toTime(11, 33), end: toTime(11, 40), period: Period.BREAK_PASSING },
+  { start: toTime(11, 40), end: toTime(13, 0), period: Period.PERIOD_5_I },
+  { start: toTime(13, 0), end: toTime(13, 30), period: Period.G_G_LUNCH},
+  { start: toTime(13, 30), end: toTime(13, 35), period: Period.OFFICE },
+  { start: toTime(13, 35), end: toTime(14, 15), period: Period.PERIOD_OFFICE_HOURS_I },
+  { start: toTime(14, 15), end: toTime(14, 40), period: Period.OFFICE },
+  { start: toTime(14, 40), end: toTime(15, 20), period: Period.PREP },
+  { start: toTime(15, 20), end: toTime(24, 0), period: Period.DONE },
+];
+export const InPersonBlockEven: any[] = [ // Has no small groups
+  { start: toTime(0, 0), end: toTime(7, 40), period: Period.NONE },
+  { start: toTime(7, 40), end: toTime(8, 20), period: Period.PERIOD_0_O },
+  { start: toTime(8, 20), end: toTime(8, 30), period: Period.PERIOD_0_PASSING },
+  { start: toTime(8, 30), end: toTime(9, 55), period: Period.PERIOD_2_I },
+  { start: toTime(9, 55), end: toTime(10, 2), period: Period.PERIOD_2_PASSING },
+  { start: toTime(10, 2), end: toTime(11, 22), period: Period.PERIOD_4_I },
+  { start: toTime(11, 22), end: toTime(11, 33), period: Period.BREAK },
+  { start: toTime(11, 33), end: toTime(11, 40), period: Period.BREAK_PASSING },
+  { start: toTime(11, 40), end: toTime(13, 0), period: Period.PERIOD_6_I },
+  { start: toTime(13, 0), end: toTime(13, 30), period: Period.G_G_LUNCH},
+  { start: toTime(13, 30), end: toTime(13, 35), period: Period.OFFICE },
+  { start: toTime(13, 35), end: toTime(14, 15), period: Period.PERIOD_OFFICE_HOURS_I },
+  { start: toTime(14, 15), end: toTime(14, 40), period: Period.OFFICE },
+  { start: toTime(14, 40), end: toTime(15, 20), period: Period.PREP },
+  { start: toTime(15, 20), end: toTime(24, 0), period: Period.DONE },
+];
 
 /**
  *


### PR DESCRIPTION
This removes the cohort names for the month of May, but it still keeps them for April. I had to modify the schedule files, so please check over them to make sure that I didn't miss anything. Also fixes #295.

Also currently untested, though I plan on getting it tested when I have more time.